### PR TITLE
Refactor pmc integral

### DIFF
--- a/code/visualizations.R
+++ b/code/visualizations.R
@@ -180,7 +180,7 @@ plotPmcMatrix <- function(phm_output, k=NULL, colors=NULL,
                           threshold=1e-3, threshold_replace="< 0.001", fmt_func=NULL,
                           include_pmc_title=T) {
   
-  k <- phm_output[[length(phm_output)]]$clusters
+  if (is.null(k)) k <- phm_output[[length(phm_output)]]$clusters
   if (is.null(colors)) colors <- brewer.pal(k, "Set1")
   if (is.null(fmt_func)) fmt_func<- function(x) round(x, 4)
 


### PR DESCRIPTION
The original `computePmc` and `computeMonteCarloPmc` functions computed the posterior probabilites (`\pi_k`) using the the `.generatePosteriorProbFunc` for each cluster separately. Each time the function is called it recomputes the marginal density/normalizing term for the posterior probabilites, (which is the same for a single observation across all clusters).

The new code computes the density matrix and then generates the posterior with one computation of the normalizing constant. This improves the computation time significantly; see the figures below for some simulations based on 2D Gaussians (K indicates number of clusters).

![a16b413c-2871-4bdd-96a6-b0e64cdf7d8d](https://github.com/user-attachments/assets/d3545a6b-dbc9-4086-b0be-d455318213e2)
